### PR TITLE
Fix branch protection context pattern for lts/*

### DIFF
--- a/setup.js
+++ b/setup.js
@@ -65,7 +65,7 @@ function setupBranchProtection() {
 {
   "required_status_checks": {
     "strict": false,
-    "contexts": ["ci lts/*", "ci (current)"]
+    "contexts": ["ci (lts/*)", "ci (current)"]
   },
   "enforce_admins": false,
   "required_pull_request_reviews": {


### PR DESCRIPTION
The CI job name includes parentheses around `lts/*`, so the branch protection context should be `ci (lts/*)` not `ci lts/*`.