### PR TITLE
Add gh repo create step to README quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ Personal template for creating TypeScript libraries.
 
 *Prequisites: Node.js, Git, and the GitHub CLI (authed). AI agents like [Claude Code](https://www.anthropic.com/claude-code) should be able to complete all these steps.*
 
-1. Run the setup script: `node setup.js [--private]`
+1. Create a new repository from this template: `gh repo create <name> --template domdomegg/typescript-library-template --clone --public` (or `--private`)
+2. Run the setup script: `node setup.js [--private]`
    - `--private` will prevent the package being published to NPM. Usually packages should be public and will be published, but if you're unsure ask the user.
-2. Complete the TODOs in `package.json` and `README.md` (don't change anything else!)
-3. Run `npm install`, then check everything works with `npm run test && npm run build && npm run lint`
-4. Commit the changes with the commit message 'Initialization from template'
+3. Complete the TODOs in `package.json` and `README.md` (don't change anything else!)
+4. Run `npm install`, then check everything works with `npm run test && npm run build && npm run lint`
+5. Commit the changes with the commit message 'Initialization from template'


### PR DESCRIPTION
## Summary
- Added a new first step to the quick start guide showing how to create a repo from the template using `gh repo create`
- Renumbered existing steps accordingly