### PR TITLE
Remove unused configureNpmToken from setup.js

### DIFF
--- a/setup.js
+++ b/setup.js
@@ -29,15 +29,6 @@ function safeExec(command, description) {
 	}
 }
 
-function configureNpmToken(isPrivate) {
-	if (!isPrivate) {
-		console.log('⏳ Fetching NPM token from secrets repository...');
-		const npmToken = exec('gh api repos/domdomegg/secrets/contents/npm.txt --jq .content | base64 -d').trim();
-		exec(`gh secret set NPM_TOKEN --body "${npmToken}"`);
-		console.log('✅ NPM_TOKEN secret configured');
-	}
-}
-
 function updatePackageJson(packageName, repoUrl, isPrivate) {
 	const packageJsonPath = path.join(__dirname, 'package.json');
 	const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
@@ -198,7 +189,6 @@ async function main() {
 
 	const isPrivate = process.argv.includes('--private');
 
-	configureNpmToken(isPrivate);
 	updatePackageJson(packageName, repoUrl, isPrivate);
 	enableGitHubActionsPermissions();
 	setupBranchProtection();


### PR DESCRIPTION
## Summary
- Remove the `configureNpmToken` function and its call from `setup.js`
- This is dead code: the CI deploy job now fetches the NPM token from GCP Secret Manager via Workload Identity Federation, so the old approach of storing an `NPM_TOKEN` repo secret is no longer used