### PR TITLE
Enable auto-merge in setup so dependabot PRs can land

### DIFF
--- a/setup.js
+++ b/setup.js
@@ -46,7 +46,7 @@ function updatePackageJson(packageName, repoUrl, isPrivate) {
 }
 
 function enableGitHubActionsPermissions() {
-	safeExec('gh repo edit --enable-issues --enable-wiki=false --enable-projects=false', 'Configuring repository settings');
+	safeExec('gh repo edit --enable-issues --enable-wiki=false --enable-projects=false --enable-auto-merge', 'Configuring repository settings');
 	safeExec('gh api repos/:owner/:repo/actions/permissions/fork-pr-contributor-approval -X PUT --input - << \'EOF\'\n{"approval_policy":"first_time_contributors_new_to_github"}\nEOF', 'Enabling first-time contributors to trigger GitHub Actions');
 	safeExec('gh api repos/:owner/:repo/actions/permissions/workflow -X PUT --input - << \'EOF\'\n{"can_approve_pull_request_reviews":true}\nEOF', 'Allowing GitHub Actions to create and approve pull requests');
 }


### PR DESCRIPTION
## Summary
- Add `--enable-auto-merge` to the `gh repo edit` call in `setup.js`.
- Without this, the centrally-synced `dependabot_automation` workflow fails with `Auto merge is not allowed for this repository (enablePullRequestAutoMerge)` on every fresh template repo, because GitHub's repo-level "Allow auto-merge" setting is off by default.

## Why
The central automation does `gh pr merge --auto --squash`, which requires repo-level auto-merge enabled. Without this fix, every new repo from the template needs manual toggling before dependabot PRs can land — encountered on a fresh repo created from this template today.

## Test plan
- [ ] Create a fresh repo from the template after this lands and confirm `gh repo view --json` shows auto-merge allowed
- [ ] Confirm a dependabot PR auto-merges once CI is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)